### PR TITLE
Adds interface_attach config option in tempest

### DIFF
--- a/devstack_vm/bin/excluded-tests.txt
+++ b/devstack_vm/bin/excluded-tests.txt
@@ -1,8 +1,3 @@
-# Hyper-V does not support attaching vNics to a running instance before Threshold
-# On Threshold it is supported, requiring Generation 2
-tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_create_list_show_delete_interfaces
-tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_hotplug_nic
-
 # See Tempest bug: https://bugs.launchpad.net/tempest/+bug/1363986
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_cross_tenant_traffic
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_multiple_security_groups

--- a/devstack_vm/devstack/local.sh
+++ b/devstack_vm/devstack/local.sh
@@ -38,6 +38,7 @@ iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
 iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi True
 iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration True
 iniset $TEMPEST_CONFIG compute-feature-enabled live_migration True
+iniset $TEMPEST_CONFIG compute-feature-enabled interface_attach False
 
 iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/images/"
 iniset $TEMPEST_CONFIG scenario img_file "cirros-0.3.3-x86_64.vhdx"


### PR DESCRIPTION
The interface_attach config option represents the capability to hotplug
vNICs. vNICs can only be hotplugged on Generation 2 VMs and Windows / Hyper-V
Server 2016.

Sets the config option to False.
Removes redundant tests from the exclude list.
