### PR TITLE
Enable nova-rescue tests

### DIFF
--- a/HyperV/scripts/create-environment.ps1
+++ b/HyperV/scripts/create-environment.ps1
@@ -260,6 +260,11 @@ ExecRetry {
     git fetch https://review.openstack.org/openstack/nova refs/changes/68/291668/2
     cherry_pick FETCH_HEAD
 
+    # nova-rescue tests are enabled. This patch adds nova-rescue feature.
+    # remove it once it merges.
+    git fetch https://review.openstack.org/openstack/nova refs/changes/59/127159/40
+    cherry_pick FETCH_HEAD
+
     & pip install $buildDir\nova
     if ($LastExitCode) { Throw "Failed to install nova fom repo" }
     popd

--- a/devstack_vm/bin/excluded-tests.txt
+++ b/devstack_vm/bin/excluded-tests.txt
@@ -6,10 +6,6 @@ tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_get_c
 tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_get_console_output_server_id_in_shutoff_status
 tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_get_console_output_with_unlimited_size
 
-# Rescue (to be removed when the feature is added)
-tempest.api.compute.servers.test_server_rescue.ServerRescueTestJSON.
-tempest.api.compute.servers.test_server_rescue_negative.ServerRescueNegativeTestJSON.
-
 # Tests needing further investigation:
 tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps
 tempest.scenario.test_network_basic_ops.TestNetworkBasicOps


### PR DESCRIPTION
Nova rescue tests are needed for the patch to land.
Cherry-picks patch, so the CI won't fail on every job.
